### PR TITLE
itunes source cleanup

### DIFF
--- a/platform/resolve/iTunesSource.py
+++ b/platform/resolve/iTunesSource.py
@@ -11,27 +11,21 @@ __license__   = "TODO"
 __all__ = [ 'iTunesSource', 'iTunesArtist', 'iTunesAlbum', 'iTunesTrack', 'iTunesMovie', 'iTunesBook', 'iTunesSearchAll' ]
 
 import Globals
-from logs import report
-
-try:
-    import logs, urllib2, datetime
-    from libs.iTunes                import globaliTunes
-    from resolve.GenericSource      import GenericSource, listSource, MERGE_TIMEOUT, SEARCH_TIMEOUT
-    from utils                      import lazyProperty, basicNestedObjectToString
-    from gevent.pool                import Pool
-    from pprint                     import pprint, pformat
-    from resolve.Resolver           import *
-    from resolve.ResolverObject     import *
-    from resolve.TitleUtils         import *
-    from libs.LibUtils              import parseDateString
-    from resolve.StampedSource      import StampedSource
-    from api.Entity                 import mapCategoryToTypes
-    from search.ScoringUtils        import *
-    from resolve.Resolver           import trackSimplify
-    from search.DataQualityUtils    import *
-except Exception:
-    report()
-    raise
+import logs, urllib2, datetime
+from libs.iTunes                import globaliTunes
+from resolve.GenericSource      import GenericSource, listSource, MERGE_TIMEOUT, SEARCH_TIMEOUT
+from utils                      import lazyProperty, basicNestedObjectToString
+from gevent.pool                import Pool
+from pprint                     import pprint, pformat
+from resolve.Resolver           import *
+from resolve.ResolverObject     import *
+from resolve.TitleUtils         import *
+from libs.LibUtils              import parseDateString
+from resolve.StampedSource      import StampedSource
+from api.Entity                 import mapCategoryToTypes
+from search.ScoringUtils        import *
+from resolve.Resolver           import trackSimplify
+from search.DataQualityUtils    import *
 
 class _iTunesObject(object):
     """
@@ -142,11 +136,11 @@ class _iTunesObject(object):
     def source(self):
         return "itunes"
     
-    @lazyProperty
+    @property
     def images(self):
         try:
             return [ self.data['artworkUrl100'] ]
-        except Exception:
+        except KeyError:
             return []
     
     def __repr__(self):
@@ -164,22 +158,22 @@ class iTunesArtist(_iTunesObject, ResolverPerson):
     def _cleanName(self, rawName):
         return cleanArtistTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
         return self.data['artistName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['artistLinkUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['artistId']
 
-    @lazyProperty
+    @property
     def amgId(self):
         return self.data.get('amgArtistId', None)
 
@@ -202,11 +196,11 @@ class iTunesArtist(_iTunesObject, ResolverPerson):
             }
                 for album in results if album.pop('collectionType', None) == 'Album' ]
 
-    @lazyProperty
+    @property
     def genres(self):
         try:
             return [ self.data['primaryGenreName'] ]
-        except Exception:
+        except KeyError:
             return []
 
     @lazyProperty
@@ -245,48 +239,41 @@ class iTunesAlbum(_iTunesObject, ResolverMediaCollection):
     def _cleanName(self, rawName):
         return cleanAlbumTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
-        suffix = ''
-        try:
-            if self.data['contentAdvisoryRating'] == 'Clean':
-                pass
-                # suffix = ' (Clean)'
-        except Exception:
-            pass
-        return '%s%s' % (self.data['collectionName'], suffix)
+        return self.data['collectionName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['collectionViewUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['collectionId']
 
-    @lazyProperty
+    @property
     def artists(self):
         result = [{
-                'name':     self.data.get('artistName', None),
-                'key':      self.data.get('artistId', None),
-                'url':      self.data.get('artistViewUrl', None),
+                'name':     self.data.get('artistName'),
+                'key':      self.data.get('artistId'),
+                'url':      self.data.get('artistViewUrl'),
                 }]
         if any(value is not None for value in result[0].values()):
             return result
         else:
             return []
 
-    @lazyProperty
+    @property
     def genres(self):
         try:
             return [ self.data['primaryGenreName'] ]
-        except Exception:
+        except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def release_date(self):
         try:
             return parseDateString(self.data['releaseDate'])
@@ -329,25 +316,18 @@ class iTunesTrack(_iTunesObject, ResolverMediaItem):
     def _cleanName(self, rawName):
         return cleanTrackTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
-        suffix = ''
-        try:
-            if self.data['contentAdvisoryRating'] == 'Clean':
-                pass
-                # suffix = ' (Clean)'
-        except Exception:
-            pass
-        return '%s%s' % (self.data['trackName'], suffix)
+        return self.data['trackName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['trackViewUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['trackId']
 
@@ -355,7 +335,7 @@ class iTunesTrack(_iTunesObject, ResolverMediaItem):
     def artistId(self):
         return self.data.get('artistId', None)
 
-    @lazyProperty
+    @property
     def artists(self):
         result = [{
                 'name':     self.data.get('artistName'),
@@ -371,7 +351,7 @@ class iTunesTrack(_iTunesObject, ResolverMediaItem):
     def albumId(self):
         return self.data.get('collectionId', None)
 
-    @lazyProperty
+    @property
     def albums(self):
         result = [{
             'name':     self.data.get('collectionName'),
@@ -383,25 +363,25 @@ class iTunesTrack(_iTunesObject, ResolverMediaItem):
         else:
             return []
 
-    @lazyProperty
+    @property
     def genres(self):
         try:
             return [ self.data['primaryGenreName'] ]
-        except Exception:
+        except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def release_date(self):
         try:
             return parseDateString(self.data['releaseDate'])
         except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def length(self):
         return float(self.data['trackTimeMillis']) / 1000
 
-    @lazyProperty
+    @property
     def preview(self):
         try:
             return self.data['previewUrl']
@@ -420,34 +400,34 @@ class iTunesMovie(_iTunesObject, ResolverMediaItem):
     def _cleanName(self, rawName):
         return cleanMovieTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
         return self.data['trackName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['trackViewUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['trackId']
 
-    @lazyProperty
+    @property
     def cast(self):
         #TODO try to improve with scraping
         return []
 
-    @lazyProperty
+    @property
     def directors(self):
         try:
             return [ { 'name' : self.data['artistName'] } ]
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def release_date(self):
         # iTunes movie release dates are LIES. If there's something in a title in parens, we can trust it. Otherwise,
         # throw it out.
@@ -457,35 +437,35 @@ class iTunesMovie(_iTunesObject, ResolverMediaItem):
         else:
             return None
 
-    @lazyProperty
+    @property
     def length(self):
         try:
             return self.data['trackTimeMillis'] / 1000
-        except Exception:
+        except KeyError:
             return -1
 
-    @lazyProperty
+    @property
     def mpaa_rating(self):
         try:
             return self.data['contentAdvisoryRating']
         except KeyError:
             return None
 
-    @lazyProperty 
+    @property 
     def genres(self):
         try:
             return [ self.data['primaryGenreName'] ]
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def description(self):
         try:
             return self.data['longDescription']
         except KeyError:
             return ''
 
-    @lazyProperty
+    @property
     def preview(self):
         try:
             return self.data['previewUrl']
@@ -504,34 +484,34 @@ class iTunesTVShow(_iTunesObject, ResolverMediaCollection):
     def _cleanName(self, rawName):
         return cleanTvTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
         return self.data['artistName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['artistLinkUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['artistId']
 
-    @lazyProperty
+    @property
     def cast(self):
         #TODO try to improve with scraping
         return []
 
-    @lazyProperty
+    @property
     def directors(self):
         try:
             return [ { 'name' : self.data['artistName'] } ]
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def release_date(self):
         year = getFilmReleaseYearFromTitle(self.raw_name)
         if year is not None:
@@ -539,18 +519,18 @@ class iTunesTVShow(_iTunesObject, ResolverMediaCollection):
         else:
             return None
 
-    @lazyProperty
+    @property
     def seasons(self):
         return -1
 
-    @lazyProperty 
+    @property 
     def genres(self):
         try:
             return [ self.data['primaryGenreName'] ]
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def description(self):
         try:
             return self.data['longDescription']
@@ -565,29 +545,29 @@ class iTunesBook(_iTunesObject, ResolverMediaItem):
     def _cleanName(self, rawName):
         return cleanBookTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
         return self.data['trackName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['trackViewUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['trackId']
 
-    @lazyProperty
+    @property
     def authors(self):
         try:
             return [ { 'name' : self.data['artistName'] } ]
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def publishers(self):
         return []
 
@@ -595,7 +575,7 @@ class iTunesBook(_iTunesObject, ResolverMediaItem):
     def release_date(self):
         try:
             return parseDateString(self.data['releaseDate'])
-        except Exception:
+        except KeyError:
             return None
 
     @property
@@ -618,22 +598,22 @@ class iTunesApp(_iTunesObject, ResolverSoftware):
     def _cleanName(self, rawName):
         return cleanAppTitle(rawName)
 
-    @lazyProperty
+    @property
     def raw_name(self):
         return self.data['trackName']
 
-    @lazyProperty
+    @property
     def url(self):
         try:
             return self.data['trackViewUrl']
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty
+    @property
     def key(self):
         return self.data['trackId']
 
-    @lazyProperty
+    @property
     def publishers(self):
         try:
             return [ { 'name' : self.data['sellerName'] } ]
@@ -644,10 +624,10 @@ class iTunesApp(_iTunesObject, ResolverSoftware):
     def release_date(self):
         try:
             return parseDateString(self.data['releaseDate'])
-        except Exception:
+        except KeyError:
             return None
 
-    @lazyProperty 
+    @property 
     def genres(self):
         try:
             if 'genres' in self.data:
@@ -656,25 +636,25 @@ class iTunesApp(_iTunesObject, ResolverSoftware):
         except KeyError:
             return []
 
-    @lazyProperty
+    @property
     def description(self):
         try:
             return self.data['description']
         except KeyError:
             return ''
 
-    @lazyProperty
+    @property
     def screenshots(self):
         try:
             return self.data['screenshotUrls']
-        except Exception:
+        except KeyError:
             return []
 
-    @lazyProperty 
+    @property 
     def images(self):
         try:
             return [ self.data['artworkUrl512'] ]
-        except Exception:
+        except KeyError:
             return []
 
 class iTunesSearchAll(ResolverProxy, ResolverSearchAll):


### PR DESCRIPTION
A few things rolled up in this CL:
- changed a lot of the lazyProperty to just property. Most of these are dictionary lookups, those are fast. We don't need to jump through hoops to cache them.
- changed most of the except Exception to catch KeyError instead. That way whatever HTTPError or others can be passed up and handled at the resolve level.
- just some general code clean up

Turns out the enrich loop is already robust against exceptions thrown from sources, so that was all that's required. I ran a resolve SxS (with a broken iTunes method). The only difference is the expected loss of itunes from sources, and also entity fields if iTunes source had contributed previously.
